### PR TITLE
Fix `UnicodeDecodeError` while opening txt files on Windows

### DIFF
--- a/bella_cleaner/cleaner/engine.py
+++ b/bella_cleaner/cleaner/engine.py
@@ -42,8 +42,8 @@ class Cleaner:
     replace_file = os.path.join(self.commons_dir, "replace.txt")
     delete_file = os.path.join(self.commons_dir, "delete.txt")
 
-    replacements = open(replace_file, "r").read().split("\n")
-    deletions = open(delete_file, "r").read().split("\n")
+    replacements = open(replace_file, "r", encoding="utf8").read().split("\n")
+    deletions = open(delete_file, "r", encoding="utf8").read().split("\n")
 
     self.replacements = [tuple(" ".join(line.strip().split()).split(" ")) for line in replacements if line]
     self.deletions = [line.strip() for line in deletions if line]
@@ -156,7 +156,7 @@ class Cleaner:
       extras = self.replace_extra[0]["extras"]
       if extras in ["append", "override"]:
         replace_file = os.path.join(self.custom_dir, "replace.txt")
-        new_pairs = open(replace_file, "r").read().split("\n")
+        new_pairs = open(replace_file, "r", encoding="utf8").read().split("\n")
         replacements = [tuple(" ".join(line.strip().split()).split(" ")) for line in new_pairs if line]
       if extras == "append":
         self.replacements += replacements
@@ -166,7 +166,7 @@ class Cleaner:
       extras = self.delete_extra[0]["extras"]
       if extras in ["append", "override"]:
         delete_file = os.path.join(self.custom_dir, "delete.txt")
-        new_dels = open(replace_file, "r").read().split("\n")
+        new_dels = open(replace_file, "r", encoding="utf8").read().split("\n")
         deletions = [line.strip() for line in new_dels if line]
       if extras == "append":
         self.deletions += deletions


### PR DESCRIPTION
Hi,

While running the following code snippet on Windows:

```py
from bella_cleaner.cleaner import Cleaner

base_dir = "./"
config_name = "acik_ulasim"

cleaner = Cleaner(base_dir=base_dir, config_name=config_name)
text = "Hello, this is Duygu!"
text = cleaner.clean(text)
```
I encountered the following error:

```console
Traceback (most recent call last):
  File "C:\Users\Ahmet\workspace\bella-turca-cleaners\t.py", line 6, in <module>
    cleaner = Cleaner(base_dir=base_dir, config_name=config_name)
  File "C:\Users\Ahmet\workspace\bella-turca-cleaners\bella_cleaner\cleaner\engine.py", line 17, in __init__
    self.load_commons()
  File "C:\Users\Ahmet\workspace\bella-turca-cleaners\bella_cleaner\cleaner\engine.py", line 45, in load_commons
    replacements = open(replace_file, "r").read().split("\n")
  File "C:\Users\Ahmet\.pyenv\pyenv-win\versions\3.10.7\lib\encodings\cp1254.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 9: character maps to <undefined>
```

This error seems to be caused by the default encoding on Windows. I think addding the `encoding="utf8"` option when opening .txt files would work.

Btw, thank you for your great efforts on Turkish NLP 🙂 